### PR TITLE
add CI/CD for python code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI-PYTHON
+
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5 
+      - uses: snok/install-poetry@v1
+
+      - name: install project
+        run: |
+          poetry install --with=dev
+        working-directory: tsumugi-python
+
+      - name: ruff check
+        run: |
+          poetry run ruff check tsumugi
+        working-directory: tsumugi-python
+
+      - name: ruff formatter
+        run: |
+          poetry run ruff format tsumugi
+        working-directory: tsumugi-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI-PYTHON
+name: python-client
 
 on: push
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.11'
           
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: snok/install-poetry@v1
         with:
           poetry-version: 1.8.2
           


### PR DESCRIPTION
Closes #3

Few notes:

1. In pyproject.toml declaring versions of dependencies by `*` is kinda not obvious and can confuse. If we want to introduce any possible latest version its better just to add dependency as `poetry add ruff` and then in toml just to add `>=5.0.0` for example. Then it says which version was installed and by specifying `>=` we would always install latest.

2. Do you any matrix for os or python version?

@SemyonSinchenko 