### PR TITLE
Updated plugins.

### DIFF
--- a/tsumugi-server/pom.xml
+++ b/tsumugi-server/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.20</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
         <protobuf.version>3.23.4</protobuf.version> <!-- This version is takes from Apache Spark -->
         <io.grpc.version>1.56.0</io.grpc.version> <!-- This version is taken from Apache Spark -->
@@ -169,7 +169,7 @@
                 <!-- see http://davidb.github.com/scala-maven-plugin -->
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>4.9.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -196,8 +196,6 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>TestSuiteReport.txt</filereports>
-                    <!-- Comma separated list of JUnit test class names to execute -->
-                    <jUnitClasses>samples.AppTest</jUnitClasses>
                 </configuration>
                 <executions>
                     <execution>
@@ -248,6 +246,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <shadedArtifactAttached>false</shadedArtifactAttached>
                     <shadeTestJar>false</shadeTestJar>

--- a/tsumugi-server/src/test/resources/log4j2.properties
+++ b/tsumugi-server/src/test/resources/log4j2.properties
@@ -1,0 +1,13 @@
+# Set everything to be logged to the console
+status = error
+name = ConsoleLogSparkTest
+
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+
+rootLogger.level = error
+rootLogger.appenderRef.stdout.ref = consoleLogger


### PR DESCRIPTION
Added log4j2.properties to reduce logs in tests.

Fixes #17
You need to run it with a Java version 11. Older is not compatible with spark and previous versions are not compatible with the protobuf plugin